### PR TITLE
Handle unsuccessful HTTP status codes on RPC requests a bit better

### DIFF
--- a/internal/aidbox/client.go
+++ b/internal/aidbox/client.go
@@ -207,6 +207,9 @@ func (client *Client) rpcRequest(ctx context.Context, method string, request int
 	if err != nil {
 		return err
 	}
+	if !isAlright(resp.StatusCode) {
+		return fmt.Errorf("unexpected status code from RPC request %d %v", resp.StatusCode, resp.Status)
+	}
 	defer func() { _ = resp.Body.Close() }()
 	var response struct {
 		Result json.RawMessage `json:"result,omitempty"`


### PR DESCRIPTION
Failing RPC requests don't give enough information, because we don't look at the HTTP status, we just try to parse the body as JSON. 

If there was an error status returned, we should log that as it'll be much more useful

Example:
https://github.com/patientsknowbest/deployment/pull/909#issuecomment-1170004262