### PR TITLE
Fix create error for aidbox_db_migration

### DIFF
--- a/aidbox/db_migration.go
+++ b/aidbox/db_migration.go
@@ -2,7 +2,6 @@ package aidbox
 
 import (
 	"context"
-	"errors"
 )
 
 // DbMigration
@@ -27,10 +26,9 @@ func (apiClient *ApiClient) CreateDbMigration(ctx context.Context, migration *Db
 		return nil, err
 	}
 
-	// Response might return other ongoing migrations, hence the search
-	createdMigration := findMigration(migration.Id, *response)
-	if createdMigration == nil {
-		return nil, errors.New("failed to create migration with id: " + migration.Id + ", response did not contain the requested migration id")
+	createdMigration, err := apiClient.GetDbMigration(ctx, migration.Id, boxId)
+	if err != nil {
+		return nil, err
 	}
 
 	return createdMigration, nil

--- a/docs/resources/db_migration.md
+++ b/docs/resources/db_migration.md
@@ -3,12 +3,14 @@
 page_title: "aidbox_db_migration Resource - terraform-provider-aidbox"
 subcategory: ""
 description: |-
-  A database migration script to be run against the db. Migrations are permanent, once created you can't update/delete them. https://docs.aidbox.app/modules-1/aidbox-search/usdpsql#sql-migrations
+  A database migration script to be run against the db. Migrations are permanent, once created you can't update them. You can delete the resource, but the migration will remain in the database.
+  https://docs.aidbox.app/modules-1/aidbox-search/usdpsql#sql-migrations
 ---
 
 # aidbox_db_migration (Resource)
 
-A database migration script to be run against the db. Migrations are permanent, once created you can't update/delete them. https://docs.aidbox.app/modules-1/aidbox-search/usdpsql#sql-migrations
+A database migration script to be run against the db. Migrations are permanent, once created you can't update them. You can delete the resource, but the migration will remain in the database.
+https://docs.aidbox.app/modules-1/aidbox-search/usdpsql#sql-migrations
 
 ## Example Usage
 

--- a/internal/provider/remove_test_migrations.sql
+++ b/internal/provider/remove_test_migrations.sql
@@ -1,3 +1,5 @@
 delete from "_migrations";
-drop index appointment_resource_idx;
-drop index patient_resource_idx;
+drop index if exists appointment_resource_idx;
+drop index if exists patient_resource_idx;
+drop index if exists practitioner_txid_idx;
+drop table if exists migration_test;

--- a/internal/provider/resource_db_migration.go
+++ b/internal/provider/resource_db_migration.go
@@ -11,7 +11,8 @@ import (
 func resourceDbMigration() *schema.Resource {
 	return &schema.Resource{
 		Description: "A database migration script to be run against the db. Migrations are permanent, once created" +
-			" you can't update/delete them. https://docs.aidbox.app/modules-1/aidbox-search/usdpsql#sql-migrations",
+			" you can't update them. You can delete the resource, but the migration will remain in the database.\n" +
+			"https://docs.aidbox.app/modules-1/aidbox-search/usdpsql#sql-migrations",
 		CreateContext: resourceDbMigrationCreate,
 		ReadContext:   resourceDbMigrationRead,
 		UpdateContext: resourceDbMigrationUpdate,

--- a/internal/provider/resource_db_migration_test.go
+++ b/internal/provider/resource_db_migration_test.go
@@ -11,7 +11,7 @@ import (
 // Having no real delete for the resource, CheckDestroy removes the migration
 // from the db after the test. In the multibox scenario the box itself is
 // deleted thus this is not required in that case.
-func TestAccResourceDbMigration(t *testing.T) {
+func TestAccResourceDbMigration_Create(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testProviderFactories,
@@ -37,7 +37,43 @@ func TestAccResourceDbMigration(t *testing.T) {
 	})
 }
 
-func TestAccResourceDbUpdate(t *testing.T) {
+func TestAccResourceDbMigration_MultipleCreates(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceDbMigration,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aidbox_db_migration.add_indexes", "id", "add_indexes"),
+				),
+			},
+			{
+				Config: testAccResourceDbMigration2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aidbox_db_migration.add_index_on_practitioner", "id", "add_index_on_practitioner"),
+				),
+			},
+			{
+				Config: testAccResourceDbMigration3,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aidbox_db_migration.add_test_table", "id", "add_test_table"),
+				),
+			},
+		},
+		CheckDestroy: func(state *terraform.State) error {
+			cmd := exec.Command("sh", "./remove_test_migrations.sh")
+			stdout, err := cmd.Output()
+			output := string(stdout)
+			if len(output) > 0 {
+				t.Log(string(stdout))
+			}
+			return err
+		},
+	})
+}
+
+func TestAccResourceDbMigration_UpdateAlwaysErrors(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testProviderFactories,
@@ -62,7 +98,7 @@ func TestAccResourceDbUpdate(t *testing.T) {
 	})
 }
 
-func TestAccResourceDbMigration_multibox(t *testing.T) {
+func TestAccResourceDbMigration_MultiBox(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testMultiboxProviderFactories,
@@ -85,6 +121,27 @@ resource "aidbox_db_migration" "add_indexes" {
   sql = <<-EOT
 	CREATE INDEX appointment_resource_idx ON public.appointment USING gin (resource);
 	CREATE INDEX patient_resource_idx ON public.patient USING gin (resource);
+  EOT
+}
+`
+
+const testAccResourceDbMigration2 = `
+resource "aidbox_db_migration" "add_index_on_practitioner" {
+  name = "add_index_on_practitioner"
+  sql = <<-EOT
+    CREATE INDEX practitioner_txid_idx on practitioner (txid);
+  EOT
+}
+`
+
+const testAccResourceDbMigration3 = `
+resource "aidbox_db_migration" "add_test_table" {
+  name = "add_test_table"
+  sql = <<-EOT
+	CREATE TABLE migration_test(
+	   id serial PRIMARY KEY,
+	   whatever VARCHAR (255) UNIQUE NOT NULL
+	);
   EOT
 }
 `


### PR DESCRIPTION
This changes the migration creation to not rely on the POST response since it not always reports back the new id. Instead read back the created migration from the server.

Also
- add some more tests
- update documentation to reflect update/delete changes