### PR TITLE
Add support for env variables for box and reasource_box PHR-12343

### DIFF
--- a/aidbox/box.go
+++ b/aidbox/box.go
@@ -8,10 +8,11 @@ import (
 
 type Box struct {
 	ResourceBase
-	Description string `json:"description"`
-	FhirVersion string `json:"fhirVersion"`
-	AccessToken string `json:"access-token,omitempty"`
-	BoxURL      string `json:"box-url,omitempty"`
+	Description string            `json:"description"`
+	FhirVersion string            `json:"fhirVersion"`
+	AccessToken string            `json:"access-token,omitempty"`
+	BoxURL      string            `json:"box-url,omitempty"`
+	Env         map[string]string `json:"env,omitempty"`
 }
 
 func (*Box) GetResourceName() string {

--- a/internal/provider/resource_box_test.go
+++ b/internal/provider/resource_box_test.go
@@ -1,8 +1,9 @@
 package provider
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccResourceBox(t *testing.T) {
@@ -16,6 +17,25 @@ func TestAccResourceBox(t *testing.T) {
 					resource.TestCheckResourceAttr("aidbox_box.mybox", "id", "mybox"),
 					resource.TestCheckResourceAttr("aidbox_box.mybox", "fhir_version", "fhir-3.0.1"),
 					resource.TestCheckResourceAttr("aidbox_box.mybox", "box_url", "http://mybox.box.local:8889"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceBoxWithEnvironmentVariablesSet(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testMultiboxProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceBoxWithEnvironmentVariablesLowerKebab,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aidbox_box.mybox", "id", "mybox"),
+					resource.TestCheckResourceAttr("aidbox_box.mybox", "fhir_version", "fhir-3.0.1"),
+					resource.TestCheckResourceAttr("aidbox_box.mybox", "box_url", "http://mybox.box.local:8889"),
+					resource.TestCheckTypeSetElemAttr("aidbox_box.mybox", "env.*", "foo-bar=bar"),
+					resource.TestCheckTypeSetElemAttr("aidbox_box.mybox", "env.*", "kaz-baz=kaz"),
 				),
 			},
 		},
@@ -44,6 +64,15 @@ resource "aidbox_box" "mybox" {
   name = "mybox"
   fhir_version  = "fhir-3.0.1" 
   description = "A box instance within multibox, a multi-tenant aidbox server"
+}
+`
+
+const testAccResourceBoxWithEnvironmentVariablesLowerKebab = `
+resource "aidbox_box" "mybox" {
+  name = "mybox"
+  fhir_version  = "fhir-3.0.1" 
+  description = "A box instance within multibox, a multi-tenant aidbox server"
+  env = ["foo-bar=bar","kaz-baz=kaz"]
 }
 `
 


### PR DESCRIPTION
[Jira ticket](https://pkbdev.atlassian.net/browse/PHR-12343)

# Support environment variables in aidbox provider
This work is needed so we can create aidbox boxes in our multibox deployment with various enviromnet variables set on the box level. WIth this we should be able to bring up boxes with additional features (e.g.: support for aidbox forms)

## What to look for

In `box.go` I added
```go
Env map[string]string `json:"env,omitempty"`
```
The reason for this beaing a map is that I conformed to the [aidbox api for creating boxes.](https://docs.aidbox.app/multibox/multibox-box-manager-api#multibox-create-box)

in `resource_box.go` I map between `[]string` and `map[string]string` because on the terraform side we set the enfironment variables as a list string:
```terraform
resource "aidbox_box" "my_box" {
  id           = "my-box"
  fhir_version = "fhir-3.0.1"
  description  = "A box instance within multibox, a multi-tenant aidbox server"
  env = [
    "ENV1=foo",
    "ENV2=bar"
  ]
}
```

Setting the `evironment variables` is optional so every existing test passed and I added a new test which tests if the variables are properly set.