### PR TITLE
Reduce dependabot churn

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4.1.2
+        uses: actions/checkout@v4
       -
         name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4.1.2
+      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: |
@@ -52,7 +52,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v4.1.2
+      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
The `checkout` action is _very_ stable because it's the one literally everyone uses - we could almost certainly even get away with `@master` to be honest. But pinning to `@v4` will still require dependabot PRs for major version bumps, whilst preventing ones for every minor version that comes out :smile: 