### PR TITLE
Fix SearchParameter resource interactions PHR-14762

### DIFF
--- a/aidbox/api_client.go
+++ b/aidbox/api_client.go
@@ -85,7 +85,12 @@ func (apiClient *ApiClient) send(ctx context.Context, requestBody interface{}, r
 	if !isAlright(res.StatusCode) {
 		return errorToTerraform(req, res, requestBody, body)
 	}
-	return json.Unmarshal(body, responseT)
+	// Deletes in general return the resource you deleted in the response body, but sometimes not (e.g. SearchParameter)
+	if httpMethod == http.MethodDelete && len(body) == 0 {
+		return nil
+	} else {
+		return json.Unmarshal(body, responseT)
+	}
 }
 
 func (apiClient *ApiClient) get(ctx context.Context, relativePath string, responseT interface{}) error {

--- a/aidbox/search_parameter.go
+++ b/aidbox/search_parameter.go
@@ -9,18 +9,19 @@ import (
 
 type SearchParameter struct {
 	ResourceBase
-	Name        string              `json:"name"`
-	Type        SearchParameterType `json:"type"`
-	Expression  string              `json:"expression"`
-	Description string              `json:"description"`
-	Url         string              `json:"url"`
-	Status      string              `json:"status"`
-	Code        string              `json:"code"`
-	Base        []string            `json:"base"`
+	ResourceType string              `json:"resourceType,omitempty"`
+	Name         string              `json:"name"`
+	Type         SearchParameterType `json:"type"`
+	Expression   string              `json:"expression"`
+	Description  string              `json:"description"`
+	Url          string              `json:"url"`
+	Status       string              `json:"status"`
+	Code         string              `json:"code"`
+	Base         []string            `json:"base"`
 }
 
 func (*SearchParameter) GetResourcePath() string {
-	return "SearchParameter"
+	return "fhir/SearchParameter"
 }
 
 type SearchParameterType int

--- a/internal/provider/resource_search_parameter.go
+++ b/internal/provider/resource_search_parameter.go
@@ -81,6 +81,7 @@ func mapSearchParameterFromData(data *schema.ResourceData) (*aidbox.SearchParame
 	res.Code = data.Get("code").(string)
 	res.Status = data.Get("status").(string)
 	res.Expression = data.Get("expression").(string)
+	res.ResourceType = "SearchParameter"
 
 	// base
 	rawBase := data.Get("base").([]interface{})

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -11,8 +11,8 @@ services:
   devbox:
     depends_on:
       - database-devbox
-    # https://docs.aidbox.app/overview/release-notes#november-2024-latest-2411
-    image: "healthsamurai/aidboxone:2411"
+    # :edge pushed on Feb 25, 2025 at 2:52 pm https://hub.docker.com/layers/healthsamurai/aidboxone/edge/images/sha256-57ecf5e02d0cacaf7c1cf4c1da5f97dbe11d4a07cf69cda25e385af8e2c460a9
+    image: "healthsamurai/aidboxone@sha256:57ecf5e02d0cacaf7c1cf4c1da5f97dbe11d4a07cf69cda25e385af8e2c460a9"
     ports:
       - "8888:8888"
     environment:


### PR DESCRIPTION
Apparently these are broken due to using legacy API - as opposed to ValueSets, which are good with legacy but broken with the new API :upside_down_face: Legacy will be removed anyway

- add fhir to the path prefix of SearchParameter resource so it is treated as a regular fhir resource
- this now makes it appear in the FHIR Artifact Registry too and also does not return a 404 when you GET after a 200 success POST/PUT - previously it was in the db table searchparameter only and you couldn't use it
- allow empty response for DELETEs

:heavy_check_mark: tried out in e2e stack with terraform development overrides