### PR TITLE
Add back ids into updating PUT calls PHR-15489

### DIFF
--- a/aidbox/api_client.go
+++ b/aidbox/api_client.go
@@ -46,7 +46,7 @@ func (apiClient *ApiClient) getResource(ctx context.Context, id string, response
 }
 
 func (apiClient *ApiClient) updateResource(ctx context.Context, resource Resource, responseTarget any) error {
-	return apiClient.put(ctx, resource, path.Join("/", resource.GetResourcePath()), responseTarget)
+	return apiClient.put(ctx, resource, path.Join("/", resource.GetResourcePath(), "/", resource.GetID()), responseTarget)
 }
 
 func (apiClient *ApiClient) deleteResource(ctx context.Context, id string, responseTarget Resource) error {

--- a/aidbox/identity_provider.go
+++ b/aidbox/identity_provider.go
@@ -24,7 +24,7 @@ type IdentityProvider struct {
 }
 
 func (g *IdentityProvider) GetResourcePath() string {
-	return "IdentityProvider/" + g.ID
+	return "IdentityProvider"
 }
 
 type IdentityProviderUserinfoSource int

--- a/internal/provider/resource_access_policy_test.go
+++ b/internal/provider/resource_access_policy_test.go
@@ -36,6 +36,27 @@ func TestAccResourceAccessPolicy_allow(t *testing.T) {
 	})
 }
 
+func TestAccResourceAccessPolicy_schema_updated(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceAccessPolicy_schema,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aidbox_access_policy.example", "schema", "{\"required\":[\"client\",\"uri\",\"request-method\"],\"properties\":{\"uri\":{\"type\":\"string\",\"pattern\":\"^/fhir/.*\"},\"client\":{\"required\":[\"id\"],\"properties\":{\"id\":{\"const\":\"postman\"}}},\"request-method\":{\"const\":\"get\"}}}"),
+				),
+			},
+			{
+				Config: testAccResourceAccessPolicy_schema_updated,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aidbox_access_policy.example", "schema", "{\"required\":[\"client\",\"uri\",\"request-method\"],\"properties\":{\"uri\":{\"type\":\"string\",\"pattern\":\"^/(fhir|ValueSet)(/.*|$)\"},\"client\":{\"required\":[\"id\"],\"properties\":{\"id\":{\"const\":\"postman\"}}},\"request-method\":{\"const\":\"get\"}}}"),
+				),
+			},
+		},
+	})
+}
+
 const testAccResourceAccessPolicy_schema = `
 resource "aidbox_access_policy" "example" {
   description = "A policy to allow postman to access data"
@@ -52,6 +73,39 @@ resource "aidbox_access_policy" "example" {
   #    "uri" = {
   #      "type" = "string"
   #      "pattern" = "^/fhir/.*"
+  #    }
+  #    "client" = {
+  #      "required" = ["id"]
+  #      "properties" = {
+  #        "id" = {
+  #          const = "postman"
+  #        }
+  #      }
+  #    }
+  #    "request-method" = {
+  #      "const" = "get"
+  #    }
+  #  }
+  #})
+}
+`
+
+const testAccResourceAccessPolicy_schema_updated = `
+resource "aidbox_access_policy" "example" {
+  description = "A policy to allow postman to access data"
+  engine = "json-schema"
+  # The test complains about whitespace differences after application when using jsonencode. 
+  # For practical purposes, jsonencode is much easier to read, so you should use that.
+  schema = "{\"required\":[\"client\",\"uri\",\"request-method\"],\"properties\":{\"uri\":{\"type\":\"string\",\"pattern\":\"^/(fhir|ValueSet)(/.*|$)\"},\"client\":{\"required\":[\"id\"],\"properties\":{\"id\":{\"const\":\"postman\"}}},\"request-method\":{\"const\":\"get\"}}}"
+  #schema = jsonencode({
+  #  "required" = [
+  #    "client",
+  #    "uri",
+  #    "request-method" ]
+  #  "properties" = {
+  #    "uri" = {
+  #      "type" = "string"
+  #      "pattern" = "^/(fhir|ValueSet)(/.*|$)"
   #    }
   #    "client" = {
   #      "required" = ["id"]


### PR DESCRIPTION
Refactoring the api client code removed the resource id by accident. Add this back. Update IdentityProvider accordingly as this was handled differently