### PR TITLE
Add token_sql support to aidbox_search resource

### DIFF
--- a/aidbox/search.go
+++ b/aidbox/search.go
@@ -12,6 +12,24 @@ type Search struct {
 	Module      string    `json:"module,omitempty"`
 	Resource    Reference `json:"resource"`
 	Where       string    `json:"where"`
+	TokenSql    *TokenSql `json:"token-sql,omitempty"`
+}
+
+// TokenSql holds the SQL fragments Aidbox uses for param-parser: token
+// search parameters. See https://docs.aidbox.app/api/rest-api/aidbox-search#token-search
+type TokenSql struct {
+	// SQL template when only code is provided
+	OnlyCode string `json:"only-code,omitempty"`
+	// SQL template when only system is provided
+	OnlySystem string `json:"only-system,omitempty"`
+	// SQL template when no system is provided
+	NoSystem string `json:"no-system,omitempty"`
+	// SQL template when both system and code are provided.
+	Both string `json:"both,omitempty"`
+	// SQL template for text search.
+	Text string `json:"text,omitempty"`
+	// Format for text search.
+	TextFormat string `json:"text-format,omitempty"`
 }
 
 func (*Search) GetResourcePath() string {

--- a/docs/resources/resource.md
+++ b/docs/resources/resource.md
@@ -32,3 +32,4 @@ resource "aidbox_resource" "my_aidbox_job" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `id_assigned` (Boolean) Whether an ID was assigned in the original resource or not

--- a/docs/resources/search.md
+++ b/docs/resources/search.md
@@ -37,7 +37,8 @@ resource "aidbox_search" "example_extension" {
 ### Optional
 
 - `module` (String) Module name
-- `param_parser` (String) Parser type for the search parameter
+- `param_parser` (String) Parser type for the search parameter (allowed values `token`|`reference`)
+- `token_sql` (Block List, Max: 1) SQL templates for token parameter handling, used when param_parser = "token". See https://docs.aidbox.app/api/rest-api/aidbox-search#token-search (see [below for nested schema](#nestedblock--token_sql))
 
 ### Read-Only
 
@@ -50,3 +51,16 @@ Required:
 
 - `resource_id` (String) The ID of the referenced resource
 - `resource_type` (String) The type of the referenced resource
+
+
+<a id="nestedblock--token_sql"></a>
+### Nested Schema for `token_sql`
+
+Optional:
+
+- `both` (String) SQL template when both system and code are provided.
+- `no_system` (String) SQL template when no system is provided.
+- `only_code` (String) SQL template when only code is provided.
+- `only_system` (String) SQL template when only system is provided.
+- `text` (String) SQL template for text search.
+- `text_format` (String) Format for text search.

--- a/internal/provider/resource_search.go
+++ b/internal/provider/resource_search.go
@@ -30,7 +30,7 @@ func resourceSchemaSearch() map[string]*schema.Schema {
 			Required:    true,
 		},
 		"param_parser": {
-			Description: "Parser type for the search parameter",
+			Description: "Parser type for the search parameter (allowed values `token`|`reference`)",
 			Type:        schema.TypeString,
 			Optional:    true,
 		},
@@ -66,6 +66,47 @@ func resourceSchemaSearch() map[string]*schema.Schema {
 				},
 			},
 		},
+		"token_sql": {
+			Description: "SQL templates for token parameter handling, used when param_parser = \"token\". See https://docs.aidbox.app/api/rest-api/aidbox-search#token-search",
+			Type:        schema.TypeList,
+			Optional:    true,
+			MinItems:    0,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"only_code": {
+						Description: "SQL template when only code is provided.",
+						Type:        schema.TypeString,
+						Optional:    true,
+					},
+					"only_system": {
+						Description: "SQL template when only system is provided.",
+						Type:        schema.TypeString,
+						Optional:    true,
+					},
+					"no_system": {
+						Description: "SQL template when no system is provided.",
+						Type:        schema.TypeString,
+						Optional:    true,
+					},
+					"both": {
+						Description: "SQL template when both system and code are provided.",
+						Type:        schema.TypeString,
+						Optional:    true,
+					},
+					"text": {
+						Description: "SQL template for text search.",
+						Type:        schema.TypeString,
+						Optional:    true,
+					},
+					"text_format": {
+						Description: "Format for text search.",
+						Type:        schema.TypeString,
+						Optional:    true,
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -86,6 +127,17 @@ func mapSearchFromData(data *schema.ResourceData) (*aidbox.Search, error) {
 
 	res.ID = res.Resource.ResourceId + "." + res.Name
 
+	if v, ok := data.GetOk("token_sql"); ok {
+		ts := v.([]interface{})[0].(map[string]interface{})
+		res.TokenSql = &aidbox.TokenSql{
+			OnlyCode:   ts["only_code"].(string),
+			OnlySystem: ts["only_system"].(string),
+			NoSystem:   ts["no_system"].(string),
+			Both:       ts["both"].(string),
+			Text:       ts["text"].(string),
+			TextFormat: ts["text_format"].(string),
+		}
+	}
 	return res, nil
 }
 
@@ -103,6 +155,19 @@ func mapSearchToData(res *aidbox.Search, data *schema.ResourceData) {
 		"resource_type": res.Resource.ResourceType,
 	}
 	data.Set("reference", append(ref, r))
+
+	if res.TokenSql != nil {
+		var ts []interface{}
+		// ignoring the error -> following the pattern above (where its ignored implicitly)
+		_ = data.Set("token_sql", append(ts, map[string]string{
+			"only_code":   res.TokenSql.OnlyCode,
+			"only_system": res.TokenSql.OnlySystem,
+			"no_system":   res.TokenSql.NoSystem,
+			"both":        res.TokenSql.Both,
+			"text":        res.TokenSql.Text,
+			"text_format": res.TokenSql.TextFormat,
+		}))
+	}
 }
 
 func resourceSearchCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/resource_search_test.go
+++ b/internal/provider/resource_search_test.go
@@ -43,6 +43,43 @@ func TestAccResourceSearch_happyPath(t *testing.T) {
 	})
 }
 
+func TestAccResourceSearch_tokenSql(t *testing.T) {
+	previousIdState := ""
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { requireSchemaMode(t) },
+		ProviderFactories: testProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceSearch_tokenSql,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "name", "prescription-status"),
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "param_parser", "token"),
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "reference.0.resource_id", "ServiceRequest"),
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "reference.0.resource_type", "Entity"),
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "token_sql.0.only_code", "resource @> 'dispensed'"),
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "token_sql.0.no_system", "resource @> 'dispensed'"),
+					resource.TestCheckResourceAttrWith("aidbox_search.example_prescription_status", "id", func(id string) error {
+						previousIdState = id
+						return nil
+					}),
+				),
+			},
+			{
+				Config: testAccResourceSearch_tokenSql_updateClause,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPtr("aidbox_search.example_prescription_status", "id", &previousIdState),
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "name", "prescription-status"),
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "param_parser", "token"),
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "reference.0.resource_id", "ServiceRequest"),
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "reference.0.resource_type", "Entity"),
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "token_sql.0.only_code", "resource @> 'fulfilled'"),
+					resource.TestCheckResourceAttr("aidbox_search.example_prescription_status", "token_sql.0.no_system", "resource @> 'fulfilled'"),
+				),
+			},
+		},
+	})
+}
+
 const testAccResourceSearch_happyPath = `
 resource "aidbox_search" "example_phone" {
   name         = "phone-number"
@@ -66,5 +103,37 @@ resource "aidbox_search" "example_phone" {
     resource_type = "Entity"
   }
   where = "phone-number = 00000000000"
+}
+`
+
+const testAccResourceSearch_tokenSql = `
+resource "aidbox_search" "example_prescription_status" {
+  name         = "prescription-status"
+  param_parser = "token"
+  reference {
+    resource_id   = "ServiceRequest"
+    resource_type = "Entity"
+  }
+  where = "true"
+  token_sql {
+    only_code = "resource @> 'dispensed'"
+    no_system = "resource @> 'dispensed'"
+  }
+}
+`
+
+const testAccResourceSearch_tokenSql_updateClause = `
+resource "aidbox_search" "example_prescription_status" {
+  name         = "prescription-status"
+  param_parser = "token"
+  reference {
+    resource_id   = "ServiceRequest"
+    resource_type = "Entity"
+  }
+  where = "true"
+  token_sql {
+    only_code = "resource @> 'fulfilled'"
+    no_system = "resource @> 'fulfilled'"
+  }
 }
 `


### PR DESCRIPTION
The aidbox_search resource only supported Aidbox's flat `where` clause, but Aidbox requires the structured `token-sql` field for any search parameter using param_parser = "token". It seems a plain `where` clause saves without error but silently fails to compile into a working search parameter, so the resulting search returns "search parameter not found" at query time with no earlier indication anything was wrong.

This was blocking a temporary, dual-format search parameter needed on ServiceRequest (matching an extension that currently appears in two different serializations depending on how the resource was written) -> see PHR-16920 (Nigeria client).

Since param_parser only accepts token|reference, and reference isn't the right parser here, token_sql support in the provider was required before this could be expressed in Terraform at all. Previously, the only way to create it was a manual PUT using the aidbox web UI.